### PR TITLE
[FIX] edi_oca: handle OperationalError and IntegrityError exceptions …

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -10,6 +10,8 @@ import logging
 import traceback
 from io import StringIO
 
+from psycopg2 import IntegrityError, OperationalError
+
 from odoo import exceptions, fields, models
 
 from odoo.addons.component.exception import NoComponentError
@@ -334,6 +336,11 @@ class EDIBackend(models.Model):
             _logger.debug(
                 "%s send failed. Marked as errored.", exchange_record.identifier
             )
+        except (OperationalError, IntegrityError):
+            # We don't want the finally block to be executed in this case as
+            # the cursor is already in an aborted state and any query will fail.
+            state = "sql_error"
+            raise
         else:
             # TODO: maybe the send handler should return desired message and state
             message = exchange_record._exchange_status_message("send_ok")
@@ -345,16 +352,18 @@ class EDIBackend(models.Model):
             )
             res = message
         finally:
-            exchange_record.write(
-                {
-                    "edi_exchange_state": state,
-                    "exchange_error": error,
-                    "exchange_error_traceback": traceback,
-                    # FIXME: this should come from _compute_exchanged_on
-                    # but somehow it's failing in send tests (in record tests it works).
-                    "exchanged_on": fields.Datetime.now(),
-                }
-            )
+            if not state == "sql_error":
+                exchange_record.write(
+                    {
+                        "edi_exchange_state": state,
+                        "exchange_error": error,
+                        "exchange_error_traceback": traceback,
+                        # FIXME: this should come from _compute_exchanged_on
+                        # but somehow it's failing in send tests
+                        # (in record tests it works).
+                        "exchanged_on": fields.Datetime.now(),
+                    }
+                )
         exchange_record.notify_action_complete("send", message=message)
         return res
 
@@ -538,20 +547,27 @@ class EDIBackend(models.Model):
             error = _get_exception_msg(err)
             state = "input_processed_error"
             res = f"Error: {error}"
+        except (OperationalError, IntegrityError):
+            # We don't want the finally block to be executed in this case as
+            # the cursor is already in an aborted state and any query will fail.
+            state = "sql_error"
+            raise
         else:
             error = traceback = None
             state = "input_processed"
         finally:
-            exchange_record.write(
-                {
-                    "edi_exchange_state": state,
-                    "exchange_error": error,
-                    "exchange_error_traceback": traceback,
-                    # FIXME: this should come from _compute_exchanged_on
-                    # but somehow it's failing in send tests (in record tests it works).
-                    "exchanged_on": fields.Datetime.now(),
-                }
-            )
+            if state != "sql_error":
+                exchange_record.write(
+                    {
+                        "edi_exchange_state": state,
+                        "exchange_error": error,
+                        "exchange_error_traceback": traceback,
+                        # FIXME: this should come from _compute_exchanged_on
+                        # but somehow it's failing in send tests
+                        # (in record tests it works).
+                        "exchanged_on": fields.Datetime.now(),
+                    }
+                )
             if (
                 state == "input_processed_error"
                 and old_state != "input_processed_error"
@@ -600,22 +616,29 @@ class EDIBackend(models.Model):
             state = "input_receive_error"
             message = exchange_record._exchange_status_message("receive_ko")
             res = f"Input error: {error}"
+        except (OperationalError, IntegrityError):
+            # We don't want the finally block to be executed in this case as
+            # the cursor is already in an aborted state and any query will fail.
+            state = "sql_error"
+            raise
         else:
             message = exchange_record._exchange_status_message("receive_ok")
             error = traceback = None
             state = "input_received"
             res = message
         finally:
-            exchange_record.write(
-                {
-                    "edi_exchange_state": state,
-                    "exchange_error": error,
-                    "exchange_error_traceback": traceback,
-                    # FIXME: this should come from _compute_exchanged_on
-                    # but somehow it's failing in send tests (in record tests it works).
-                    "exchanged_on": fields.Datetime.now(),
-                }
-            )
+            if not state == "sql_error":
+                exchange_record.write(
+                    {
+                        "edi_exchange_state": state,
+                        "exchange_error": error,
+                        "exchange_error_traceback": traceback,
+                        # FIXME: this should come from _compute_exchanged_on
+                        # but somehow it's failing in send tests
+                        # (in record tests it works).
+                        "exchanged_on": fields.Datetime.now(),
+                    }
+                )
         exchange_record.notify_action_complete("receive", message=message)
         return res
 


### PR DESCRIPTION
…to prevent finally block execution in aborted transaction state